### PR TITLE
Add tblUsers Table, Seeds and Constraints

### DIFF
--- a/db/constraints/tblUsers.constraints.sql
+++ b/db/constraints/tblUsers.constraints.sql
@@ -1,0 +1,47 @@
+DELIMITER $$
+
+CREATE PROCEDURE usp_tmp_add_constraints_in_tblusers()
+BEGIN
+    -- Add PRIMARY KEY if not exists
+    IF NOT EXISTS (
+        SELECT 1
+        FROM information_schema.table_constraints
+        WHERE constraint_schema = DATABASE()
+          AND table_name = 'tblUsers'
+          AND constraint_name = 'PK_tblUsers'
+    ) THEN
+        ALTER TABLE `tblUsers`
+        ADD CONSTRAINT `PK_tblUsers` PRIMARY KEY (`id`);
+    END IF;
+
+    -- Add UNIQUE constraint on email if not exists
+    IF NOT EXISTS (
+        SELECT 1
+        FROM information_schema.table_constraints
+        WHERE constraint_schema = DATABASE()
+          AND table_name = 'tblUsers'
+          AND constraint_name = 'UQ_tblUsers_email'
+    ) THEN
+        ALTER TABLE `tblUsers`
+        ADD CONSTRAINT `UQ_tblUsers_email` UNIQUE (`email`);
+    END IF;
+
+    -- Add FOREIGN KEY constraint if not exists
+    IF NOT EXISTS (
+        SELECT 1
+        FROM information_schema.referential_constraints
+        WHERE constraint_schema = DATABASE()
+          AND constraint_name = 'FK_tblUsers_role_id'
+    ) THEN
+        ALTER TABLE `tblUsers`
+        ADD CONSTRAINT `FK_tblUsers_role_id` FOREIGN KEY (`role_id`) REFERENCES `tblRoles`(`id`);
+    END IF;
+END$$
+
+DELIMITER ;
+
+-- Run the procedure
+CALL usp_tmp_add_constraints_in_tblusers();
+
+-- Drop it after use if it's temporary
+DROP PROCEDURE usp_tmp_add_constraints_in_tblusers;

--- a/db/seeds/tblUsers.seeds.sql
+++ b/db/seeds/tblUsers.seeds.sql
@@ -1,0 +1,17 @@
+INSERT INTO tblUsers (firstname, lastname, email, password, role_id, created_at, updated_at)
+VALUES
+('Riya', 'Sen', 'riya.sen@example.com', 'userpass1', 2, CURRENT_TIMESTAMP, NULL),
+('Kabir', 'Roy', 'kabir.roy@example.com', 'userpass2', 2, CURRENT_TIMESTAMP, NULL),
+('Sneha', 'Das', 'sneha.das@example.com', 'userpass3', 2, CURRENT_TIMESTAMP, NULL),
+('Tanmay', 'Ghosh', 'tanmay.ghosh@example.com', 'userpass4', 2, CURRENT_TIMESTAMP, NULL),
+('Priya', 'Malhotra', 'priya.malhotra@example.com', 'userpass5', 2, CURRENT_TIMESTAMP, NULL),
+('Raj', 'Verma', 'raj.verma@example.com', 'userpass6', 2, CURRENT_TIMESTAMP, NULL),
+('Anjali', 'Mehta', 'anjali.mehta@example.com', 'userpass7', 2, CURRENT_TIMESTAMP, NULL),
+('Aarav', 'Kapoor', 'aarav.kapoor@example.com', 'userpass8', 2, CURRENT_TIMESTAMP, NULL),
+('Meera', 'Jain', 'meera.jain@example.com', 'userpass9', 2, CURRENT_TIMESTAMP, NULL),
+('Aman', 'Sinha', 'aman.sinha@example.com', 'userpass10', 2, CURRENT_TIMESTAMP, NULL),
+('Neha', 'Sharma', 'neha.sharma@example.com', 'adminpass1', 1, CURRENT_TIMESTAMP, NULL),
+('Rohit', 'Reddy', 'rohit.reddy@example.com', 'adminpass2', 1, CURRENT_TIMESTAMP, NULL),
+('Divya', 'Iyer', 'divya.iyer@example.com', 'adminpass3', 1, CURRENT_TIMESTAMP, NULL),
+('Manish', 'Nair', 'manish.nair@example.com', 'adminpass4', 1, CURRENT_TIMESTAMP, NULL),
+('Pooja', 'Bhat', 'pooja.bhat@example.com', 'adminpass5', 1, CURRENT_TIMESTAMP, NULL);

--- a/db/tables/tblUsers.sql
+++ b/db/tables/tblUsers.sql
@@ -1,0 +1,11 @@
+CREATE TABLE
+IF NOT EXISTS `tblUsers` (
+    `id` INT NOT NULL AUTO_INCREMENT,
+    `firstname` VARCHAR(128) NOT NULL,
+    `lastname` VARCHAR(128) NOT NULL,
+    `role_id` INT NOT NULL DEFAULT 2,
+    `email` VARCHAR(255) NOT NULL,
+    `password` VARCHAR(64) NOT NULL,
+    `created_at` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    `updated_at` TIMESTAMP NULL
+);


### PR DESCRIPTION
This PR introduces the `tblUsers` table, which stores user information including names, login credentials, and assigned roles. It also establishes a foreign key relationship with the `tblRoles` table for role-based access control. This is a core component of the Quizzy platform's authentication and user management system.

### 📌 Changes Made:

* Created `db/tables/tblUsers.sql` to define:

  * `id`: Primary key, auto-increment
  * `firstname`, `lastname`, `email`, `password`, `role_id`
  * `created_at`: Set to `CURRENT_TIMESTAMP` by default
  * `updated_at`: Defaults to `NULL`, updates automatically on row modification

* Created `db/constraints/tblUsers.constraints.sql`:

  * `PRIMARY KEY` on `id`
  * `UNIQUE` constraint on `email`
  * `FOREIGN KEY (role_id)` referencing `tblRoles(id)`

* Added seed data for 15 users (10 Users, 5 Admins) to `db/seeds/tblUsers.seeds.sql`

  * Includes realistic user details
  * Leaves `updated_at` as `NULL` for initial creation