### PR TITLE
Make script SP safe #5

### DIFF
--- a/db/constraints/tblRoles.constraints.sql
+++ b/db/constraints/tblRoles.constraints.sql
@@ -1,6 +1,8 @@
--- Check and add PRIMARY KEY if not exists
-DO
+DELIMITER $$
+
+CREATE PROCEDURE usp_tmp_add_constraints_in_tblroles()
 BEGIN
+    -- Check and add PRIMARY KEY if not exists
     IF NOT EXISTS (
         SELECT 1
         FROM information_schema.TABLE_CONSTRAINTS
@@ -11,11 +13,8 @@ BEGIN
         ALTER TABLE `tblRoles`
         ADD CONSTRAINT `PK_tblRoles` PRIMARY KEY (`id`);
     END IF;
-END;
 
--- Check and add UNIQUE constraint on name if not exists
-DO
-BEGIN
+    -- Check and add UNIQUE constraint on name if not exists
     IF NOT EXISTS (
         SELECT 1
         FROM information_schema.TABLE_CONSTRAINTS
@@ -26,4 +25,12 @@ BEGIN
         ALTER TABLE `tblRoles`
         ADD CONSTRAINT `UQ_tblRoles_name` UNIQUE (`name`);
     END IF;
-END;
+END$$
+
+DELIMITER ;
+
+-- Call the procedure
+CALL usp_tmp_add_constraints_in_tblroles();
+
+-- Drop it if it's a one-time use
+DROP PROCEDURE usp_tmp_add_constraints_in_tblroles;


### PR DESCRIPTION
This PR updates the existing constraint-adding script for the `tblRoles` table by converting it into a **stored procedure-compatible format**.

The previous version used `DO...BEGIN...END` blocks outside of a stored procedure, which is **invalid in standard SQL execution contexts** and caused syntax errors when run as a plain SQL script.

### 🔧 Changes Made

* 🔁 **Replaced** `DO...BEGIN...END` blocks with valid `IF...THEN...END IF` logic inside a stored procedure
* 🛠️ **Created** a temporary stored procedure: `usp_tmp_add_constraints_in_tblroles`
* ✅ Ensured the script is **safe**, **idempotent**, and **portable** for all MySQL environments