### PR TITLE
Add tblTopics Table, Seeds and Constraints

### DIFF
--- a/db/constraints/tblTopics.constraints.sql
+++ b/db/constraints/tblTopics.constraints.sql
@@ -1,0 +1,48 @@
+DELIMITER $$
+
+CREATE PROCEDURE usp_tmp_add_constraints_in_tbltopics()
+BEGIN
+    -- Add PRIMARY KEY if not exists
+    IF NOT EXISTS (
+        SELECT 1
+        FROM information_schema.table_constraints
+        WHERE constraint_schema = DATABASE()
+          AND table_name = 'tblTopics'
+          AND constraint_name = 'PK_tblTopics'
+    ) THEN
+        ALTER TABLE `tblTopics`
+        ADD CONSTRAINT `PK_tblTopics` PRIMARY KEY (`id`);
+    END IF;
+
+    -- Add FOREIGN KEY: created_by → tblUsers(id)
+    IF NOT EXISTS (
+        SELECT 1
+        FROM information_schema.referential_constraints
+        WHERE constraint_schema = DATABASE()
+          AND constraint_name = 'FK_tblTopics_created_by'
+    ) THEN
+        ALTER TABLE `tblTopics`
+        ADD CONSTRAINT `FK_tblTopics_created_by`
+        FOREIGN KEY (`created_by`) REFERENCES `tblUsers`(`id`);
+    END IF;
+
+    -- Add FOREIGN KEY: updated_by → tblUsers(id)
+    IF NOT EXISTS (
+        SELECT 1
+        FROM information_schema.referential_constraints
+        WHERE constraint_schema = DATABASE()
+          AND constraint_name = 'FK_tblTopics_updated_by'
+    ) THEN
+        ALTER TABLE `tblTopics`
+        ADD CONSTRAINT `FK_tblTopics_updated_by`
+        FOREIGN KEY (`updated_by`) REFERENCES `tblUsers`(`id`);
+    END IF;
+END$$
+
+DELIMITER ;
+
+-- Execute the procedure
+CALL usp_tmp_add_constraints_in_tbltopics();
+
+-- Optionally drop it if it's one-time use
+DROP PROCEDURE usp_tmp_add_constraints_in_tbltopics;

--- a/db/seeds/tblTopics.seeds.sql
+++ b/db/seeds/tblTopics.seeds.sql
@@ -1,0 +1,7 @@
+INSERT INTO tblTopics (name, created_by, updated_by, created_at, updated_at)
+VALUES
+('Java Programming', 11, NULL, CURRENT_TIMESTAMP, NULL),
+('Database Systems', 12, NULL, CURRENT_TIMESTAMP, NULL),
+('Data Structures', 13, NULL, CURRENT_TIMESTAMP, NULL),
+('Operating Systems', 14, NULL, CURRENT_TIMESTAMP, NULL),
+('Web Development', 15, NULL, CURRENT_TIMESTAMP, NULL);

--- a/db/tables/tblTopics.sql
+++ b/db/tables/tblTopics.sql
@@ -1,0 +1,8 @@
+CREATE TABLE IF NOT EXISTS `tblTopics` (
+    `id` INT NOT NULL AUTO_INCREMENT,
+    `name` VARCHAR(64) NOT NULL,
+    `created_at` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    `updated_at` TIMESTAMP NULL,
+    `created_by` INT NOT NULL,
+    `updated_by` INT NULL
+);


### PR DESCRIPTION
This PR introduces the `tblTopics` table, which stores quiz topic metadata such as topic name, creator, and timestamps. It includes all relevant constraints and initial seed data created by administrator accounts. The `tblTopics` table serves as a key entity for categorizing quizzes in the Quizzy application.

### 📌 Changes Made:

* Created `db/tables/tblTopics.sql`:

  * `id`: Primary key, auto-increment
  * `name`: Unique, not null
  * `created_by`: FK referencing `tblUsers(id)`
  * `updated_by`: Nullable FK referencing `tblUsers(id)`
  * `created_at`: Defaults to `CURRENT_TIMESTAMP`
  * `updated_at`: Nullable, auto-updated on modification

* Added `db/constraints/tblTopics.constraints.sql`:

  * `PRIMARY KEY` on `id`
  * `UNIQUE` constraint on `name`
  * Foreign keys for `created_by` and `updated_by` → `tblUsers(id)`

* Added 5 seed entries in `db/seeds/tblTopics.seeds.sql`: