### PR TITLE
Add tblQuiz Table, Constraints and Seeds

### DIFF
--- a/db/constraints/tblQuiz.constraints.sql
+++ b/db/constraints/tblQuiz.constraints.sql
@@ -1,0 +1,60 @@
+DELIMITER $$
+
+CREATE PROCEDURE usp_tmp_add_constraints_in_tblquiz()
+BEGIN
+    -- Add PRIMARY KEY if not exists
+    IF NOT EXISTS (
+        SELECT 1
+        FROM information_schema.table_constraints
+        WHERE constraint_schema = DATABASE()
+          AND table_name = 'tblQuiz'
+          AND constraint_name = 'PK_tblQuiz'
+    ) THEN
+        ALTER TABLE `tblQuiz`
+        ADD CONSTRAINT `PK_tblQuiz` PRIMARY KEY (`id`);
+    END IF;
+
+    -- Add FOREIGN KEY: topic_id → tblTopics(id)
+    IF NOT EXISTS (
+        SELECT 1
+        FROM information_schema.referential_constraints
+        WHERE constraint_schema = DATABASE()
+          AND constraint_name = 'FK_tblQuiz_topic_id'
+    ) THEN
+        ALTER TABLE `tblQuiz`
+        ADD CONSTRAINT `FK_tblQuiz_topic_id`
+        FOREIGN KEY (`topic_id`) REFERENCES `tblTopics`(`id`);
+    END IF;
+
+    -- Add FOREIGN KEY: created_by → tblUsers(id)
+    IF NOT EXISTS (
+        SELECT 1
+        FROM information_schema.referential_constraints
+        WHERE constraint_schema = DATABASE()
+          AND constraint_name = 'FK_tblQuiz_created_by'
+    ) THEN
+        ALTER TABLE `tblQuiz`
+        ADD CONSTRAINT `FK_tblQuiz_created_by`
+        FOREIGN KEY (`created_by`) REFERENCES `tblUsers`(`id`);
+    END IF;
+
+    -- Add FOREIGN KEY: updated_by → tblUsers(id)
+    IF NOT EXISTS (
+        SELECT 1
+        FROM information_schema.referential_constraints
+        WHERE constraint_schema = DATABASE()
+          AND constraint_name = 'FK_tblQuiz_updated_by'
+    ) THEN
+        ALTER TABLE `tblQuiz`
+        ADD CONSTRAINT `FK_tblQuiz_updated_by`
+        FOREIGN KEY (`updated_by`) REFERENCES `tblUsers`(`id`);
+    END IF;
+END$$
+
+DELIMITER ;
+
+-- Call the procedure
+CALL usp_tmp_add_constraints_in_tblquiz();
+
+-- Drop procedure after use
+DROP PROCEDURE usp_tmp_add_constraints_in_tblquiz;

--- a/db/seeds/tblQuiz.seeds.sql
+++ b/db/seeds/tblQuiz.seeds.sql
@@ -1,0 +1,39 @@
+-- Java Programming (Topic ID: 1, Created by: 11)
+INSERT INTO tblQuiz (name, topic_id, void, duration, total_questions, created_at, updated_at, created_by, updated_by) VALUES
+('Java Basics Quiz', 1, FALSE, 900, 5, CURRENT_TIMESTAMP, NULL, 11, NULL),
+('OOP in Java', 1, FALSE, 1200, 10, CURRENT_TIMESTAMP, NULL, 11, NULL),
+('Java Exception Handling', 1, FALSE, 1500, 5, CURRENT_TIMESTAMP, NULL, 11, NULL),
+('Java Collections Framework', 1, FALSE, 1800, 10, CURRENT_TIMESTAMP, NULL, 11, NULL),
+('Multithreading in Java', 1, FALSE, 2100, 10, CURRENT_TIMESTAMP, NULL, 11, NULL);
+
+-- Database Systems (Topic ID: 2, Created by: 12)
+INSERT INTO tblQuiz (name, topic_id, void, duration, total_questions, created_at, updated_at, created_by, updated_by) VALUES
+('SQL Basics', 2, FALSE, 900, 5, CURRENT_TIMESTAMP, NULL, 12, NULL),
+('Normalization Quiz', 2, FALSE, 1200, 10, CURRENT_TIMESTAMP, NULL, 12, NULL),
+('Joins and Subqueries', 2, FALSE, 1500, 5, CURRENT_TIMESTAMP, NULL, 12, NULL),
+('Indexing & Optimization', 2, FALSE, 1800, 10, CURRENT_TIMESTAMP, NULL, 12, NULL),
+('Transactions & ACID', 2, FALSE, 2100, 10, CURRENT_TIMESTAMP, NULL, 12, NULL);
+
+-- Data Structures (Topic ID: 3, Created by: 13)
+INSERT INTO tblQuiz (name, topic_id, void, duration, total_questions, created_at, updated_at, created_by, updated_by) VALUES
+('Arrays and Strings', 3, FALSE, 900, 5, CURRENT_TIMESTAMP, NULL, 13, NULL),
+('Stacks and Queues', 3, FALSE, 1200, 10, CURRENT_TIMESTAMP, NULL, 13, NULL),
+('Linked Lists', 3, FALSE, 1500, 5, CURRENT_TIMESTAMP, NULL, 13, NULL),
+('Trees and Graphs', 3, FALSE, 1800, 10, CURRENT_TIMESTAMP, NULL, 13, NULL),
+('Sorting Algorithms', 3, FALSE, 2100, 10, CURRENT_TIMESTAMP, NULL, 13, NULL);
+
+-- Operating Systems (Topic ID: 4, Created by: 14)
+INSERT INTO tblQuiz (name, topic_id, void, duration, total_questions, created_at, updated_at, created_by, updated_by) VALUES
+('OS Basics', 4, FALSE, 900, 5, CURRENT_TIMESTAMP, NULL, 14, NULL),
+('Process Management', 4, FALSE, 1200, 10, CURRENT_TIMESTAMP, NULL, 14, NULL),
+('Memory Management', 4, FALSE, 1500, 5, CURRENT_TIMESTAMP, NULL, 14, NULL),
+('File Systems', 4, FALSE, 1800, 10, CURRENT_TIMESTAMP, NULL, 14, NULL),
+('Deadlocks and Concurrency', 4, FALSE, 2100, 10, CURRENT_TIMESTAMP, NULL, 14, NULL);
+
+-- Web Development (Topic ID: 5, Created by: 15)
+INSERT INTO tblQuiz (name, topic_id, void, duration, total_questions, created_at, updated_at, created_by, updated_by) VALUES
+('HTML & CSS Quiz', 5, FALSE, 900, 5, CURRENT_TIMESTAMP, NULL, 15, NULL),
+('JavaScript Basics', 5, FALSE, 1200, 10, CURRENT_TIMESTAMP, NULL, 15, NULL),
+('DOM & Events', 5, FALSE, 1500, 5, CURRENT_TIMESTAMP, NULL, 15, NULL),
+('Frontend Frameworks', 5, FALSE, 1800, 10, CURRENT_TIMESTAMP, NULL, 15, NULL),
+('Web APIs & AJAX', 5, FALSE, 2100, 10, CURRENT_TIMESTAMP, NULL, 15, NULL);

--- a/db/tables/tblQuiz.sql
+++ b/db/tables/tblQuiz.sql
@@ -1,0 +1,12 @@
+CREATE TABLE IF NOT EXISTS `tblQuiz` (
+    `id` INT NOT NULL AUTO_INCREMENT,
+    `name` VARCHAR(256) NOT NULL,
+    `topic_id` INT NOT NULL,
+    `void` BOOLEAN NOT NULL,
+    `duration` INT NULL,
+    `total_questions` INT NOT NULL,
+    `created_at` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    `updated_at` TIMESTAMP NULL,
+    `created_by` INT NOT NULL,
+    `updated_by` INT NULL
+);


### PR DESCRIPTION
This PR introduces the `tblQuiz` table, which stores metadata for quizzes in the Quizzy platform. Each quiz is linked to a topic and tracks creation metadata, including the creator (admin user). The table supports fields for quiz duration (in seconds), total number of questions (5 or 10), and a soft-delete flag via the `void` column. Additionally, 25 quizzes are seeded - 5 for each of the existing 5 topics.

### 📌 Changes Made:

* **Created table definition** in `db/tables/tblQuiz.sql`:

  * `id`: Primary key
  * `name`: Quiz title
  * `topic_id`: FK → `tblTopics(id)`
  * `void`: Boolean flag to mark inactive quizzes
  * `duration`: Duration in seconds
  * `total_questions`: 5 or 10 (per system rules)
  * `created_at`: Default `CURRENT_TIMESTAMP`
  * `updated_at`: Nullable
  * `created_by`: FK → `tblUsers(id)` (admin)
  * `updated_by`: Nullable FK → `tblUsers(id)`

* **Added constraints** in `db/constraints/tblQuiz.constraints.sql`:

  * `PRIMARY KEY (id)`
  * `FOREIGN KEY (topic_id)` references `tblTopics(id)`
  * `FOREIGN KEY (created_by)` and `updated_by` reference `tblUsers(id)`

* **Seeded 25 quizzes** in `db/seeds/tblQuiz.seeds.sql`: