### PR TITLE
Add tblErrorLogs Table and Constraints

### DIFF
--- a/db/constraints/tblErrorLogs.constraints.sql
+++ b/db/constraints/tblErrorLogs.constraints.sql
@@ -1,0 +1,24 @@
+DELIMITER $$
+
+CREATE PROCEDURE usp_tmp_add_constraints_in_tblerrorlogs()
+BEGIN
+    -- Add PRIMARY KEY on id if not exists
+    IF NOT EXISTS (
+        SELECT 1
+        FROM information_schema.table_constraints
+        WHERE constraint_schema = DATABASE()
+          AND table_name = 'tblErrorLogs'
+          AND constraint_name = 'PK_tblErrorLogs'
+    ) THEN
+        ALTER TABLE `tblErrorLogs`
+        ADD CONSTRAINT `PK_tblErrorLogs` PRIMARY KEY (`id`);
+    END IF;
+END$$
+
+DELIMITER ;
+
+-- Call the procedure
+CALL usp_tmp_add_constraints_in_tblerrorlogs();
+
+-- Drop the procedure if it's temporary
+DROP PROCEDURE usp_tmp_add_constraints_in_tblerrorlogs;

--- a/db/tables/tblErrorLogs.sql
+++ b/db/tables/tblErrorLogs.sql
@@ -1,0 +1,9 @@
+CREATE TABLE IF NOT EXISTS `tblErrorLogs` (
+    `id` INT AUTO_INCREMENT,
+    `procedure_name` VARCHAR(256),
+    `params` TEXT,
+    `error_code` INT,
+    `sqlstate_code` CHAR(5),
+    `occured_at` DATETIME DEFAULT CURRENT_TIMESTAMP,
+    `message` TEXT
+);


### PR DESCRIPTION
This PR introduces the `tblErrorLogs` table to log database errors, particularly those occurring in stored procedures. It captures critical metadata including procedure name, input parameters, error codes, SQL state, and descriptive messages, enabling better debugging and audit tracking for database-level exceptions.

### 📌 Changes Made:

* **Created table definition** in `db/tables/tblErrorLogs.sql`:

  * `id`: auto-increment
  * `procedure_name`: Name of the stored procedure that caused the error
  * `params`: Text field for input parameters passed to the procedure
  * `error_code`: MySQL error code
  * `sqlstate_code`: SQLSTATE code (CHAR(5))
  * `occured_at`: Defaults to `CURRENT_TIMESTAMP` for logging error occurrence time
  * `message`: Detailed error description for debugging

* **Created table constraints** in `db/constraints/tblErrorLogs.constraints.sql`:

  * `id`: Primary key